### PR TITLE
Fix gelf uncompressed scheme

### DIFF
--- a/gelf/writer.go
+++ b/gelf/writer.go
@@ -199,13 +199,6 @@ func newBuffer() *bytes.Buffer {
 func (w *Writer) WriteMessage(m *Message) (err error) {
 	mBuf := newBuffer()
 	defer bufPool.Put(mBuf)
-	// when compression is disabled, prewrite the magic byte before encoding
-	// so we dont have to re-copy the slice after
-	if w.CompressionType == CompressNone {
-		if _, err = mBuf.Write([]byte{0x1f, 0x3c}); err != nil {
-			return err
-		}
-	}
 	if err = m.MarshalJSONBuf(mBuf); err != nil {
 		return err
 	}

--- a/gelf/writer_test.go
+++ b/gelf/writer_test.go
@@ -66,7 +66,7 @@ func sendAndRecvMsg(msg *Message, compress CompressType) (*Message, error) {
 // tests single-message (non-chunked) messages that are split over
 // multiple lines
 func TestWriteSmallMultiLine(t *testing.T) {
-	for _, i := range []CompressType{CompressGzip, CompressZlib} {
+	for _, i := range []CompressType{CompressGzip, CompressZlib, CompressNone} {
 		msgData := "awesomesauce\nbananas"
 
 		msg, err := sendAndRecv(msgData, i)


### PR DESCRIPTION
The previous code (#2) was based on https://github.com/lusis/gelfd/commit/79b893ada7867eee1eb78b94cc97cf0199aac32b but apparently the scheme was changed for [GelfMessage.java](https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/inputs/codecs/gelf/GELFMessage.java#L147) i.e. no more magic header.

This removes the magic header and also optimize the ReadMessage code a bit i.e.
no more temporary buffer to store the uncompressed json.
