### PR TITLE
A GELF message may not contain more than 128 chunks

### DIFF
--- a/gelf/writer.go
+++ b/gelf/writer.go
@@ -126,7 +126,7 @@ func (w *Writer) writeChunked(zBytes []byte) (err error) {
 	b := make([]byte, 0, ChunkSize)
 	buf := bytes.NewBuffer(b)
 	nChunksI := numChunks(zBytes)
-	if nChunksI > 255 {
+	if nChunksI > 128 {
 		return fmt.Errorf("msg too large, would need %d chunks", nChunksI)
 	}
 	nChunks := uint8(nChunksI)


### PR DESCRIPTION
According to GELF docs, a GELF message may not consist of more than 128 chunks:

> A message MUST NOT consist of more than 128 chunks.
> [http://docs.graylog.org/en/latest/pages/gelf.html](http://docs.graylog.org/en/latest/pages/gelf.html)

Logstash is also dropping message with more than 128 chunks, e.g.:

```
{:timestamp=>"2016-03-29T14:20:33.126000+0200", :message=>"Gelfd failed to parse a message skipping", :exception=>#<Gelfd::TooManyChunksError: 207 greater than 128>, :backtrace=>["/opt/logstash/vendor/bundle/jruby/1.9/gems/gelfd-0.2.0/lib/gelfd/chunked_parser.rb:40:in `parse_chunk'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/gelfd-0.2.0/lib/gelfd/chunked_parser.rb:8:in `parse'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/gelfd-0.2.0/lib/gelfd/parser.rb:10:in `parse'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-gelf-2.0.2/lib/logstash/inputs/gelf.rb:90:in `udp_listener'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-gelf-2.0.2/lib/logstash/inputs/gelf.rb:63:in `run'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.2-java/lib/logstash/pipeline.rb:331:in `inputworker'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.2-java/lib/logstash/pipeline.rb:325:in `start_input'"], :level=>:warn}
```

This PR simply changes the limit at which go-gelf drops the message to 128 chunks instead of 255 chunks.
