### PR TITLE
Update documentation to reflect default branch changes and GoPkg.in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ can be run over any stream or datagram transport protocol, it has
 special support ([chunking]) to allow long messages to be split over
 multiple datagrams.
 
+Versions
+--------
+
+In order to enable versionning of this package with Go, this project
+is using GoPkg.in. The default branch of this project will be v1
+for some time to prevent breaking clients. We encourage all project
+to change their imports to the new GoPkg.in URIs as soon as possible.
+
+To see up to date code, make sure to switch to the master branch.
+
+v1.0.0
+------
+
 This implementation currently supports only UDP as a transport
 protocol. TCP and TLS are unsupported.
 
@@ -25,7 +38,16 @@ Installing
 
 go-gelf is go get-able:
 
+    go get gopkg.in/Graylog2/go-gelf.v1/gelf
+
+    or
+
 	go get github.com/Graylog2/go-gelf/gelf
+
+This will get you version 1.0.0, with only UDP support and legacy API.
+Newer versions are available through GoPkg.in:
+
+    go get gopkg.in/Graylog2/go-gelf.v2/gelf
 
 Usage
 -----
@@ -39,7 +61,7 @@ giving us both centralized and local logs.  (Redundancy is nice).
 
 	import (
 		"flag"
-		"github.com/Graylog2/go-gelf/gelf"
+		"gopkg.in/Graylog2/go-gelf.v1/gelf"
 		"io"
 		"log"
 		"os"


### PR DESCRIPTION
This PR changes the documentation to reflect changes to the branching strategy and GoPkg.in usage to enable versionning of the package. With some testing this morning, I was able to determine that we will have to use major version numbers whenever we change the public API, due to the behaviour of GoPkg.in. 

GoPkg.in lets you only target a single number version (v1, v2, v3...) and that will target the latest version number in that specific major release. If you have v1.0.0 and v1.1.0, getting v1 from GoPkg.in will yield v1.1.0.

Once this PR is merged, we should immediately create a v1 branch from master, and update the project to use that as its default branch. This will let us merge PR #9 on master and then tag  or branch that to v2.

After some time, I would suggest putting master back as the default branch, but doing that will break clients that have not migrated to the GoPkg.in import path, so we will probably have to wait a while.