### PR TITLE
Fix crash when the server drops and does not return

### DIFF
--- a/gelf/tcpreader.go
+++ b/gelf/tcpreader.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"time"
 )
 
 type TCPReader struct {
@@ -13,16 +14,21 @@ type TCPReader struct {
 	messages chan []byte
 }
 
-func newTCPReader(addr string) (*TCPReader, chan string, error) {
+type conn_channels struct {
+	drop    chan string
+	confirm chan string
+}
+
+func newTCPReader(addr string) (*TCPReader, chan string, chan string, error) {
 	var err error
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("ResolveTCPAddr('%s'): %s", addr, err)
+		return nil, nil, nil, fmt.Errorf("ResolveTCPAddr('%s'): %s", addr, err)
 	}
 
 	listener, err := net.ListenTCP("tcp", tcpAddr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("ListenTCP: %s", err)
+		return nil, nil, nil, fmt.Errorf("ListenTCP: %s", err)
 	}
 
 	r := &TCPReader{
@@ -30,26 +36,68 @@ func newTCPReader(addr string) (*TCPReader, chan string, error) {
 		messages: make(chan []byte, 100), // Make a buffered channel with at most 100 messages
 	}
 
-	signal := make(chan string, 1)
+	close_signal := make(chan string, 1)
+	done_signal := make(chan string, 1)
 
-	go r.listenUntilCloseSignal(signal)
+	go r.listenUntilCloseSignal(close_signal, done_signal)
 
-	return r, signal, nil
+	return r, close_signal, done_signal, nil
 }
 
-func (r *TCPReader) listenUntilCloseSignal(signal chan string) {
-	defer func() { signal <- "done" }()
-	defer r.listener.Close()
+func (r *TCPReader) accepter(connections chan net.Conn) {
 	for {
 		conn, err := r.listener.Accept()
 		if err != nil {
 			break
 		}
-		go handleConnection(conn, r.messages)
+		connections <- conn
+	}
+}
+
+func (r *TCPReader) listenUntilCloseSignal(close_signal chan string, done_signal chan string) {
+	defer func() { done_signal <- "done" }()
+	defer r.listener.Close()
+	var conns []conn_channels
+	connections_channel := make(chan net.Conn, 1)
+	go r.accepter(connections_channel)
+	for {
 		select {
-		case sig := <-signal:
+		case conn := <-connections_channel:
+			drop_signal := make(chan string, 1)
+			drop_confirm := make(chan string, 1)
+			channels := conn_channels{drop: drop_signal, confirm: drop_confirm}
+			go handleConnection(conn, r.messages, drop_signal, drop_confirm)
+			conns = append(conns, channels)
+		default:
+		}
+
+		select {
+		case sig := <-close_signal:
 			if sig == "stop" {
-				break
+				if len(conns) >= 1 {
+					for _, s := range conns {
+						if s.drop != nil {
+							s.drop <- "drop"
+							<-s.confirm
+							conns = append(conns[:0], conns[1:]...)
+						}
+					}
+					return
+				} else {
+					close_signal <- "stop"
+				}
+			}
+			if sig == "drop" {
+				if len(conns) >= 1 {
+					for _, s := range conns {
+						if s.drop != nil {
+							s.drop <- "drop"
+							<-s.confirm
+							conns = append(conns[:0], conns[1:]...)
+						}
+					}
+				}
+				done_signal <- "done"
 			}
 		default:
 		}
@@ -60,19 +108,41 @@ func (r *TCPReader) addr() string {
 	return r.listener.Addr().String()
 }
 
-func handleConnection(conn net.Conn, messages chan<- []byte) {
+func handleConnection(conn net.Conn, messages chan<- []byte, drop_signal chan string, drop_confirm chan string) {
+	defer func() { drop_confirm <- "done" }()
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
 	var b []byte
 	var err error
+	drop := false
+	can_drop := false
 
 	for {
+		conn.SetDeadline(time.Now().Add(2 * time.Second))
 		if b, err = reader.ReadBytes(0); err != nil {
-			continue
-		}
-		if len(b) > 0 {
+			if drop {
+				return
+			}
+		} else if len(b) > 0 {
 			messages <- b
+			can_drop = true
+			if drop {
+				return
+			}
+		} else if drop {
+			return
+		}
+		select {
+		case sig := <-drop_signal:
+			if sig == "drop" {
+				drop = true
+				time.Sleep(1 * time.Second)
+				if can_drop {
+					return
+				}
+			}
+		default:
 		}
 	}
 }

--- a/gelf/tcpreader.go
+++ b/gelf/tcpreader.go
@@ -73,7 +73,7 @@ func (r *TCPReader) listenUntilCloseSignal(closeSignal chan string, doneSignal c
 
 		select {
 		case sig := <-closeSignal:
-			if sig == "stop" {
+			if sig == "stop" || sig == "drop" {
 				if len(conns) >= 1 {
 					for _, s := range conns {
 						if s.drop != nil {
@@ -82,22 +82,15 @@ func (r *TCPReader) listenUntilCloseSignal(closeSignal chan string, doneSignal c
 							conns = append(conns[:0], conns[1:]...)
 						}
 					}
-					return
-				} else {
+					if sig == "stop" {
+						return
+					}
+				} else if sig == "stop" {
 					closeSignal <- "stop"
 				}
-			}
-			if sig == "drop" {
-				if len(conns) >= 1 {
-					for _, s := range conns {
-						if s.drop != nil {
-							s.drop <- "drop"
-							<-s.confirm
-							conns = append(conns[:0], conns[1:]...)
-						}
-					}
+				if sig == "drop" {
+					doneSignal <- "done"
 				}
-				doneSignal <- "done"
 			}
 		default:
 		}

--- a/gelf/tcpwriter_test.go
+++ b/gelf/tcpwriter_test.go
@@ -216,7 +216,7 @@ func TestWrite2MessagesWithServerDropTCP(t *testing.T) {
 }
 
 func setupConnections() (*TCPReader, chan string, chan string, *TCPWriter, error) {
-	r, close_signal, done_signal, err := newTCPReader("127.0.0.1:0")
+	r, closeSignal, doneSignal, err := newTCPReader("127.0.0.1:0")
 
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("newTCPReader: %s", err)
@@ -227,11 +227,11 @@ func setupConnections() (*TCPReader, chan string, chan string, *TCPWriter, error
 		return nil, nil, nil, nil, fmt.Errorf("NewTCPWriter: %s", err)
 	}
 
-	return r, close_signal, done_signal, w, nil
+	return r, closeSignal, doneSignal, w, nil
 }
 
 func sendAndRecvTCP(msgData string) (*Message, error) {
-	r, close_signal, done_signal, w, err := setupConnections()
+	r, closeSignal, doneSignal, w, err := setupConnections()
 	if err != nil {
 		return nil, err
 	}
@@ -240,8 +240,8 @@ func sendAndRecvTCP(msgData string) (*Message, error) {
 		return nil, fmt.Errorf("w.Write: %s", err)
 	}
 
-	close_signal <- "stop"
-	done := <-done_signal
+	closeSignal <- "stop"
+	done := <-doneSignal
 	if done != "done" {
 		return nil, errors.New("Wrong signal received")
 	}
@@ -255,7 +255,7 @@ func sendAndRecvTCP(msgData string) (*Message, error) {
 }
 
 func sendAndRecvMsgTCP(msg *Message) (*Message, error) {
-	r, close_signal, done_signal, w, err := setupConnections()
+	r, closeSignal, doneSignal, w, err := setupConnections()
 	if err != nil {
 		return nil, err
 	}
@@ -264,8 +264,8 @@ func sendAndRecvMsgTCP(msg *Message) (*Message, error) {
 		return nil, fmt.Errorf("w.Write: %s", err)
 	}
 
-	close_signal <- "stop"
-	done := <-done_signal
+	closeSignal <- "stop"
+	done := <-doneSignal
 	if done != "done" {
 		return nil, errors.New("Wrong signal received")
 	}
@@ -280,7 +280,7 @@ func sendAndRecvMsgTCP(msg *Message) (*Message, error) {
 }
 
 func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message, *Message, error) {
-	r, close_signal, done_signal, w, err := setupConnections()
+	r, closeSignal, doneSignal, w, err := setupConnections()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -289,8 +289,8 @@ func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message
 		return nil, nil, fmt.Errorf("w.Write: %s", err)
 	}
 
-	close_signal <- "drop"
-	done := <-done_signal
+	closeSignal <- "drop"
+	done := <-doneSignal
 	if done != "done" {
 		return nil, nil, fmt.Errorf("Wrong signal received: %s", done)
 	}
@@ -308,8 +308,8 @@ func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message
 		return nil, nil, fmt.Errorf("write 2 w.Write: %s", err)
 	}
 
-	close_signal <- "stop"
-	done = <-done_signal
+	closeSignal <- "stop"
+	done = <-doneSignal
 	if done != "done" {
 		return nil, nil, errors.New("Wrong signal received")
 	}
@@ -324,7 +324,7 @@ func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message
 }
 
 func sendAndRecv2MessagesWithServerDropTCP(msgData1 string, msgData2 string) (*Message, error) {
-	r, close_signal, done_signal, w, err := setupConnections()
+	r, closeSignal, doneSignal, w, err := setupConnections()
 	if err != nil {
 		return nil, err
 	}
@@ -333,8 +333,8 @@ func sendAndRecv2MessagesWithServerDropTCP(msgData1 string, msgData2 string) (*M
 		return nil, fmt.Errorf("w.Write: %s", err)
 	}
 
-	close_signal <- "stop"
-	done := <-done_signal
+	closeSignal <- "stop"
+	done := <-doneSignal
 	if done != "done" {
 		return nil, fmt.Errorf("Wrong signal received: %s", done)
 	}

--- a/gelf/tcpwriter_test.go
+++ b/gelf/tcpwriter_test.go
@@ -289,6 +289,8 @@ func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message
 		return nil, nil, fmt.Errorf("w.Write: %s", err)
 	}
 
+	time.Sleep(200 * time.Millisecond)
+
 	closeSignal <- "drop"
 	done := <-doneSignal
 	if done != "done" {
@@ -304,9 +306,11 @@ func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message
 	if _, err = w.Write([]byte(msgData2)); err != nil {
 		return nil, nil, fmt.Errorf("write 1 w.Write: %s", err)
 	}
+	time.Sleep(200 * time.Millisecond)
 	if _, err = w.Write([]byte(msgData2)); err != nil {
 		return nil, nil, fmt.Errorf("write 2 w.Write: %s", err)
 	}
+	time.Sleep(200 * time.Millisecond)
 
 	closeSignal <- "stop"
 	done = <-doneSignal

--- a/gelf/tcpwriter_test.go
+++ b/gelf/tcpwriter_test.go
@@ -19,7 +19,7 @@ func TestNewTCPWriter(t *testing.T) {
 }
 
 func TestNewTCPWriterConfig(t *testing.T) {
-	r, _, err := newTCPReader("127.0.0.1:0")
+	r, _, _, err := newTCPReader("127.0.0.1:0")
 	if err != nil {
 		t.Error("Could not open TCPReader")
 		return
@@ -202,23 +202,36 @@ func TestWrite2MessagesWithConnectionDropTCP(t *testing.T) {
 	assertMessages(msg2, "Second message", msgData2, t)
 }
 
-func setupConnections() (*TCPReader, chan string, *TCPWriter, error) {
-	r, signal, err := newTCPReader("127.0.0.1:0")
+func TestWrite2MessagesWithServerDropTCP(t *testing.T) {
+	msgData1 := "First message\nThis happens before the server drops"
+	msgData2 := "Second message\nThis happens after the server drops"
+
+	msg1, err := sendAndRecv2MessagesWithServerDropTCP(msgData1, msgData2)
+	if err != nil {
+		t.Errorf("sendAndRecv2MessagesWithDropTCP: %s", err)
+		return
+	}
+
+	assertMessages(msg1, "First message", msgData1, t)
+}
+
+func setupConnections() (*TCPReader, chan string, chan string, *TCPWriter, error) {
+	r, close_signal, done_signal, err := newTCPReader("127.0.0.1:0")
 
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("newTCPReader: %s", err)
+		return nil, nil, nil, nil, fmt.Errorf("newTCPReader: %s", err)
 	}
 
 	w, err := NewTCPWriter(r.addr())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("NewTCPWriter: %s", err)
+		return nil, nil, nil, nil, fmt.Errorf("NewTCPWriter: %s", err)
 	}
 
-	return r, signal, w, nil
+	return r, close_signal, done_signal, w, nil
 }
 
 func sendAndRecvTCP(msgData string) (*Message, error) {
-	r, signal, w, err := setupConnections()
+	r, close_signal, done_signal, w, err := setupConnections()
 	if err != nil {
 		return nil, err
 	}
@@ -227,9 +240,9 @@ func sendAndRecvTCP(msgData string) (*Message, error) {
 		return nil, fmt.Errorf("w.Write: %s", err)
 	}
 
-	signal <- "stop"
-	done := <-signal
-	if done == "done" {
+	close_signal <- "stop"
+	done := <-done_signal
+	if done != "done" {
 		return nil, errors.New("Wrong signal received")
 	}
 
@@ -242,7 +255,7 @@ func sendAndRecvTCP(msgData string) (*Message, error) {
 }
 
 func sendAndRecvMsgTCP(msg *Message) (*Message, error) {
-	r, signal, w, err := setupConnections()
+	r, close_signal, done_signal, w, err := setupConnections()
 	if err != nil {
 		return nil, err
 	}
@@ -251,9 +264,9 @@ func sendAndRecvMsgTCP(msg *Message) (*Message, error) {
 		return nil, fmt.Errorf("w.Write: %s", err)
 	}
 
-	signal <- "stop"
-	done := <-signal
-	if done == "done" {
+	close_signal <- "stop"
+	done := <-done_signal
+	if done != "done" {
 		return nil, errors.New("Wrong signal received")
 	}
 
@@ -267,13 +280,19 @@ func sendAndRecvMsgTCP(msg *Message) (*Message, error) {
 }
 
 func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message, *Message, error) {
-	r, signal, w, err := setupConnections()
+	r, close_signal, done_signal, w, err := setupConnections()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	if _, err = w.Write([]byte(msgData1)); err != nil {
 		return nil, nil, fmt.Errorf("w.Write: %s", err)
+	}
+
+	close_signal <- "drop"
+	done := <-done_signal
+	if done != "done" {
+		return nil, nil, fmt.Errorf("Wrong signal received: %s", done)
 	}
 
 	message1, err := r.readMessage()
@@ -289,9 +308,9 @@ func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message
 		return nil, nil, fmt.Errorf("write 2 w.Write: %s", err)
 	}
 
-	signal <- "stop"
-	done := <-signal
-	if done == "done" {
+	close_signal <- "stop"
+	done = <-done_signal
+	if done != "done" {
 		return nil, nil, errors.New("Wrong signal received")
 	}
 
@@ -302,4 +321,38 @@ func sendAndRecv2MessagesWithDropTCP(msgData1 string, msgData2 string) (*Message
 
 	w.Close()
 	return message1, message2, nil
+}
+
+func sendAndRecv2MessagesWithServerDropTCP(msgData1 string, msgData2 string) (*Message, error) {
+	r, close_signal, done_signal, w, err := setupConnections()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = w.Write([]byte(msgData1)); err != nil {
+		return nil, fmt.Errorf("w.Write: %s", err)
+	}
+
+	close_signal <- "stop"
+	done := <-done_signal
+	if done != "done" {
+		return nil, fmt.Errorf("Wrong signal received: %s", done)
+	}
+
+	message1, err := r.readMessage()
+	if err != nil {
+		return nil, fmt.Errorf("readmessage: %s", err)
+	}
+
+	// Need to write twice to force the detection of the dropped connection
+	// The first write will not cause an error, but the subsequent ones will
+	for {
+		_, err = w.Write([]byte(msgData2))
+		if err != nil {
+			break
+		}
+	}
+
+	w.Close()
+	return message1, nil
 }

--- a/gelf/writer.go
+++ b/gelf/writer.go
@@ -27,5 +27,8 @@ type GelfWriter struct {
 
 // Close connection and interrupt blocked Read or Write operations
 func (w *GelfWriter) Close() error {
+	if w.conn == nil {
+		return nil
+	}
 	return w.conn.Close()
 }


### PR DESCRIPTION
This adds a new test that closes the server and continue to
write to it. It uncovered a bug with an unhandled nil pointer. It
also uncovered some issues in the reconnection logic that were fixed
at the same time.