### PR TITLE
Feat: Use more precise time stamps

### DIFF
--- a/gelf/message.go
+++ b/gelf/message.go
@@ -143,7 +143,7 @@ func constructMessage(p []byte, hostname string, facility string, file string, l
 		Host:     hostname,
 		Short:    string(short),
 		Full:     string(full),
-		TimeUnix: float64(time.Now().Unix()),
+		TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 		Level:    6, // info
 		Facility: facility,
 		Extra: map[string]interface{}{

--- a/gelf/tcpwriter_test.go
+++ b/gelf/tcpwriter_test.go
@@ -152,7 +152,7 @@ func TestExtraDataTCP(t *testing.T) {
 		Host:     "fake-host",
 		Short:    string(short),
 		Full:     string(full),
-		TimeUnix: float64(time.Now().Unix()),
+		TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 		Level:    6, // info
 		Facility: "writer_test",
 		Extra:    extra,

--- a/gelf/udpwriter_test.go
+++ b/gelf/udpwriter_test.go
@@ -190,7 +190,7 @@ func TestExtraData(t *testing.T) {
 		Host:     "fake-host",
 		Short:    string(short),
 		Full:     string(full),
-		TimeUnix: float64(time.Now().Unix()),
+		TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 		Level:    6, // info
 		Facility: "udpwriter_test",
 		Extra:    extra,
@@ -254,7 +254,7 @@ func BenchmarkWriteBestSpeed(b *testing.B) {
 			Host:     w.hostname,
 			Short:    "short message",
 			Full:     "full message",
-			TimeUnix: float64(time.Now().Unix()),
+			TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 			Level:    6, // info
 			Facility: w.Facility,
 			Extra:    map[string]interface{}{"_file": "1234", "_line": "3456"},
@@ -280,7 +280,7 @@ func BenchmarkWriteNoCompression(b *testing.B) {
 			Host:     w.hostname,
 			Short:    "short message",
 			Full:     "full message",
-			TimeUnix: float64(time.Now().Unix()),
+			TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 			Level:    6, // info
 			Facility: w.Facility,
 			Extra:    map[string]interface{}{"_file": "1234", "_line": "3456"},
@@ -306,7 +306,7 @@ func BenchmarkWriteDisableCompressionCompletely(b *testing.B) {
 			Host:     w.hostname,
 			Short:    "short message",
 			Full:     "full message",
-			TimeUnix: float64(time.Now().Unix()),
+			TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 			Level:    6, // info
 			Facility: w.Facility,
 			Extra:    map[string]interface{}{"_file": "1234", "_line": "3456"},
@@ -332,7 +332,7 @@ func BenchmarkWriteDisableCompressionAndPreencodeExtra(b *testing.B) {
 			Host:     w.hostname,
 			Short:    "short message",
 			Full:     "full message",
-			TimeUnix: float64(time.Now().Unix()),
+			TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 			Level:    6, // info
 			Facility: w.Facility,
 			RawExtra: json.RawMessage(`{"_file":"1234","_line": "3456"}`),


### PR DESCRIPTION
The implementation, as was, sent messages with a timestamp exact to the second.

This leads to messages created very close to each other as being reported with the same timestamp, which in turn can lead to loss of ordering of log messages - cf. [a related issue in the graylog project](https://github.com/Graylog2/graylog2-server/issues/2741).

With these changes we calculate the timestamp with precision up to nanoseconds. Unfortunately, it seems like only precision up to milliseconds is taken into account (cf. above issue), but this is all we can do here for now - the rest must be solved elsewhere.