### PR TITLE
fixed bug. Multi routine call WriteMessage will make race for same bu…

### DIFF
--- a/gelf/message.go
+++ b/gelf/message.go
@@ -113,9 +113,7 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (m *Message) toBytes() (messageBytes []byte, err error) {
-	buf := newBuffer()
-	defer bufPool.Put(buf)
+func (m *Message) toBytes(buf *bytes.Buffer) (messageBytes []byte, err error) {
 	if err = m.MarshalJSONBuf(buf); err != nil {
 		return nil, err
 	}

--- a/gelf/tcpwriter.go
+++ b/gelf/tcpwriter.go
@@ -43,7 +43,9 @@ func NewTCPWriter(addr string) (*TCPWriter, error) {
 // filled out appropriately.  In general, clients will want to use
 // Write, rather than WriteMessage.
 func (w *TCPWriter) WriteMessage(m *Message) (err error) {
-	messageBytes, err := m.toBytes()
+	buf := newBuffer()
+	defer bufPool.Put(buf)
+	messageBytes, err := m.toBytes(buf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```golang
// issue.go
package main

import (
    "time"
    "gopkg.in/Graylog2/go-gelf.v2/gelf"
)

func main() {
    addr := ""
	writer, _ := gelf.NewTCPWriter(addr)
	parall := 10000
	goroutineSize := 100
	for q := 0; q < goroutineSize; q++ {
		go func() {
			for j := 0; j < parall/goroutineSize; j++ {
				writer.WriteMessage(&gelf.Message{
					Version:  "1.0",
					Host:     "hostname",
					Short:    "-",
					TimeUnix: float64(time.Now().UnixNano()),
					Level:    6,
					Facility: "",
				})
			}
		}()
	}
	select {}
}
```

run `go run -race issue.go`; will get DATA RACE WARNING.
it is a bugfix: https://github.com/lpflpf/go-gelf/tree/v2