### PR TITLE
Set Hostname programatically in gelf instead of OS Hostname.  

### DIFF
--- a/gelf/writer.go
+++ b/gelf/writer.go
@@ -28,7 +28,7 @@ import (
 type Writer struct {
 	mu               sync.Mutex
 	conn             net.Conn
-	hostname         string
+	Hostname         string
 	Facility         string // defaults to current process name
 	CompressionLevel int    // one of the consts from compress/flate
 	CompressionType  CompressType
@@ -107,7 +107,7 @@ func NewWriter(addr string) (*Writer, error) {
 	if w.conn, err = net.Dial("udp", addr); err != nil {
 		return nil, err
 	}
-	if w.hostname, err = os.Hostname(); err != nil {
+	if w.Hostname, err = os.Hostname(); err != nil {
 		return nil, err
 	}
 
@@ -326,7 +326,7 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 
 	m := Message{
 		Version:  "1.1",
-		Host:     w.hostname,
+		Host:     w.Hostname,
 		Short:    string(short),
 		Full:     string(full),
 		TimeUnix: float64(time.Now().Unix()),

--- a/gelf/writer_test.go
+++ b/gelf/writer_test.go
@@ -249,7 +249,7 @@ func BenchmarkWriteBestSpeed(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		w.WriteMessage(&Message{
 			Version:  "1.1",
-			Host:     w.hostname,
+			Host:     w.Hostname,
 			Short:    "short message",
 			Full:     "full message",
 			TimeUnix: float64(time.Now().Unix()),
@@ -275,7 +275,7 @@ func BenchmarkWriteNoCompression(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		w.WriteMessage(&Message{
 			Version:  "1.1",
-			Host:     w.hostname,
+			Host:     w.Hostname,
 			Short:    "short message",
 			Full:     "full message",
 			TimeUnix: float64(time.Now().Unix()),
@@ -301,7 +301,7 @@ func BenchmarkWriteDisableCompressionCompletely(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		w.WriteMessage(&Message{
 			Version:  "1.1",
-			Host:     w.hostname,
+			Host:     w.Hostname,
 			Short:    "short message",
 			Full:     "full message",
 			TimeUnix: float64(time.Now().Unix()),
@@ -327,7 +327,7 @@ func BenchmarkWriteDisableCompressionAndPreencodeExtra(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		w.WriteMessage(&Message{
 			Version:  "1.1",
-			Host:     w.hostname,
+			Host:     w.Hostname,
 			Short:    "short message",
 			Full:     "full message",
 			TimeUnix: float64(time.Now().Unix()),


### PR DESCRIPTION
Currently, the OS host-name is set by the gelf library. There should be an option to set Hostname by user whenever it is required.  I have made changes in the code accordingly. 

Let me know if any code enhancement or changes is required to merge the code with the master. 