### PR TITLE
add a Go Module file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/graylog2/go-gelf
+
+go 1.12


### PR DESCRIPTION
Please consider adding a `go.sum` file and tagging a semver compatible release, eg. `v0.0.1` or `v1.0.0` that others can pin to when they use this library.

For this PR I used the GitHub import path as that's how we were importing it in the go.mod file I was trying to clean up. If you prefer to keep using gopkg.in I can change it to use that as well, but Go Modules more or less makes gopkg.in unnecessary. Just let me know.

This PR is only for the v1 branch.

Thanks for your consideration!